### PR TITLE
Add missing key in translation files, breaking the switch on another lang

### DIFF
--- a/src/locale/lang/de.json
+++ b/src/locale/lang/de.json
@@ -34,7 +34,8 @@
       "noEmailReceived": "Keine Bestätigungs-E-Mail?",
       "sendEmail": "Erneut senden",
       "needToBeAdmin": "Um fortzufahren, müssen Sie Administrator des Geschäfts sein",
-      "pleaseContact": "Vielen Dank für den Kontakt"
+      "pleaseContact": "Vielen Dank für den Kontakt",
+      "manageAccountTooltip": "Manage account"
     }
   },
   "billing": {

--- a/src/locale/lang/es.json
+++ b/src/locale/lang/es.json
@@ -34,7 +34,8 @@
       "noEmailReceived": "¿No ha llegado el correo electrónico de confirmación?",
       "sendEmail": "Reenviar",
       "needToBeAdmin": "Para continuar, debes ser administrador de la tienda",
-      "pleaseContact": "Ponte en contacto con nosotros"
+      "pleaseContact": "Ponte en contacto con nosotros",
+      "manageAccountTooltip": "Manage account"
     }
   },
   "billing": {

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -34,7 +34,8 @@
       "noEmailReceived": "Pas d'email de confirmation ?",
       "sendEmail": "Renvoyer",
       "needToBeAdmin": "Pour continuer, vous devez être administrateur de la boutique",
-      "pleaseContact": "Merci de contacter"
+      "pleaseContact": "Merci de contacter",
+      "manageAccountTooltip": "Gérer mon compte"
     }
   },
   "billing": {

--- a/src/locale/lang/it.json
+++ b/src/locale/lang/it.json
@@ -34,7 +34,8 @@
       "noEmailReceived": "Non hai ricevuto l'e-mail di conferma?",
       "sendEmail": "Invia di nuovo",
       "needToBeAdmin": "Per continuare, devi essere l'amministratore del negozio",
-      "pleaseContact": "Si prega di contattare"
+      "pleaseContact": "Si prega di contattare",
+      "manageAccountTooltip": "Manage account"
     }
   },
   "billing": {

--- a/src/locale/lang/nl.json
+++ b/src/locale/lang/nl.json
@@ -34,7 +34,8 @@
       "noEmailReceived": "Geen bevestigingsmail?",
       "sendEmail": "Doorsturen",
       "needToBeAdmin": "Om verder te gaan, moet u een administrator van de winkel zijn.",
-      "pleaseContact": "Neem alstublieft contact op met"
+      "pleaseContact": "Neem alstublieft contact op met",
+      "manageAccountTooltip": "Manage account"
     }
   },
   "billing": {

--- a/src/locale/lang/pl.json
+++ b/src/locale/lang/pl.json
@@ -34,7 +34,8 @@
       "noEmailReceived": "E-mail z potwierdzeniem nie dotarł?",
       "sendEmail": "Wróć",
       "needToBeAdmin": "Aby kontynuować, musisz być administratorem sklepu.",
-      "pleaseContact": "Prosimy o kontakt"
+      "pleaseContact": "Prosimy o kontakt",
+      "manageAccountTooltip": "Manage account"
     }
   },
   "billing": {

--- a/src/locale/lang/pt.json
+++ b/src/locale/lang/pt.json
@@ -34,7 +34,8 @@
       "noEmailReceived": "Nenhum e-mail de confirmação?",
       "sendEmail": "Reenviar",
       "needToBeAdmin": "Para continuar, deverá ser um administrador da loja.",
-      "pleaseContact": "Por favor entre em contacto"
+      "pleaseContact": "Por favor entre em contacto",
+      "manageAccountTooltip": "Manage account"
     }
   },
   "billing": {


### PR DESCRIPTION
When we try to use another locale for the account component, it simply disappear because one of the string is missing from the other lang files.

![Capture d’écran du 2020-12-21 18-10-42](https://user-images.githubusercontent.com/6768917/102803599-c3072180-43b8-11eb-80fa-46015d24cc70.png)

This PR adds at least the English value.