### PR TITLE
Merge strings from fallback locale to avoid errors

### DIFF
--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -79,7 +79,11 @@ export const use = function use(l) {
     case 'en':
     default:
       lang = en;
+      // For the default case, stop here
+      return;
   }
+
+  lang = deepmerge(en, lang, {clone: true});
 };
 
 export const i18n = function i18n(fn) {


### PR DESCRIPTION
Even if #52 added missing translated data for all languages files, it appears other ones were missing and forgotten.

To avoid this error appearing again and again, we should fallback on the English language if a string is not translated.