### PR TITLE
Apply event name emitted in parent component

### DIFF
--- a/src/components/PsAccounts.vue
+++ b/src/components/PsAccounts.vue
@@ -33,7 +33,7 @@
           v-if="!psAccountsIsUptodate"
           :account-is-uptodate="psAccountsIsUptodate"
           :is-loading="installLoading"
-          @install="updatePsAccounts()"
+          @update="updatePsAccounts()"
         />
         <template v-else>
           <AccountNotEnabled


### PR DESCRIPTION
When creating a new Update component from the Install one, it seems one event you listen to has been mispelled, preventing upgrades to be started:

https://github.com/PrestaShopCorp/prestashop_accounts_vue_components/blob/33d7ced5217bc31b007083ac06f0b09a92ac5d61/src/components/alert/AccountNotUpdated.vue#L64-L74