### PR TITLE
Moving accounts storybook to distribution infra

### DIFF
--- a/.github/workflows/ci-cd-alpha.yml
+++ b/.github/workflows/ci-cd-alpha.yml
@@ -24,42 +24,41 @@ jobs:
           echo $GOOGLE_APPLICATION_CREDENTIALS > token.json
           gcloud auth activate-service-account --key-file=token.json
           gcloud container clusters get-credentials $GCLOUD_CLUSTER \
-          --zone europe-west1-c --project psessentials-integration
+          --zone europe-west1-c --project distribution-integration
           gcloud auth configure-docker
           rm token.json
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GCLOUD_CLUSTER: ${{ secrets.GCLOUD_CLUSTER }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.INTEGRATION_GOOGLE_APPLICATION_CREDENTIALS }}
+          GCLOUD_CLUSTER: ${{ secrets.INTEGRATION_GCLOUD_CLUSTER }}
 
       - name: Terraform init
         working-directory: cloud
         run: |
-          terraform init -backend-config="bucket=psessentials-production"
+          terraform init -backend-config="bucket=distribution-integration"
           terraform workspace select alpha
           terraform fmt
         env:
-          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_CREDENTIALS: ${{ secrets.INTEGRATION_GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Docker pull
         continue-on-error: true
-        run: docker pull "eu.gcr.io/psessentials-integration/accounts-vue-components-package:latest"
+        run: docker pull "eu.gcr.io/distribution-integration/accounts-vue-components-package:latest"
 
       - name: Build package
         run: |
           docker build \
             --target=package \
-            --cache-from="eu.gcr.io/psessentials-integration/accounts-vue-components-package:latest" \
-            --tag="eu.gcr.io/psessentials-integration/accounts-vue-components-package:latest" .
-          docker push "eu.gcr.io/psessentials-integration/accounts-vue-components-package:latest"
+            --cache-from="eu.gcr.io/distribution-integration/accounts-vue-components-package:latest" \
+            --tag="eu.gcr.io/distribution-integration/accounts-vue-components-package:latest" .
+          docker push "eu.gcr.io/distribution-integration/accounts-vue-components-package:latest"
 
       - name: Build and push finale image
         run: |
           docker build . \
-            --tag="eu.gcr.io/psessentials-integration/accounts-vue-components:latest" \
-            --cache-from="eu.gcr.io/psessentials-integration/accounts-vue-components-package:latest"
-          docker push "eu.gcr.io/psessentials-integration/accounts-vue-components:latest"
+            --tag="eu.gcr.io/distribution-integration/accounts-vue-components:latest" \
+            --cache-from="eu.gcr.io/distribution-integration/accounts-vue-components-package:latest"
+          docker push "eu.gcr.io/distribution-integration/accounts-vue-components:latest"
         env:
-          GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
           TAG: ${{ steps.get_tag.outputs.TAG }}
 
       - name: Terraform apply
@@ -67,4 +66,4 @@ jobs:
         run: terraform apply -auto-approve
         env:
           SHA: ${{ github.sha }}
-          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_CREDENTIALS: ${{ secrets.INTEGRATION_GOOGLE_APPLICATION_CREDENTIALS }}

--- a/.github/workflows/ci-cd-stable.yml
+++ b/.github/workflows/ci-cd-stable.yml
@@ -25,42 +25,41 @@ jobs:
           echo $GOOGLE_APPLICATION_CREDENTIALS > token.json
           gcloud auth activate-service-account --key-file=token.json
           gcloud container clusters get-credentials $GCLOUD_CLUSTER \
-          --zone europe-west1-c --project psessentials-production
+          --zone europe-west1-c --project distribution-production-308520
           gcloud auth configure-docker
           rm token.json
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GCLOUD_CLUSTER: ${{ secrets.GCLOUD_CLUSTER }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.PRODUCTION_GOOGLE_APPLICATION_CREDENTIALS }}
+          GCLOUD_CLUSTER: ${{ secrets.PRODUCTION_GCLOUD_CLUSTER }}
 
       - name: Terraform init
         working-directory: cloud
         run: |
-          terraform init -backend-config="bucket=psessentials-production"
+          terraform init -backend-config="bucket=integration-ditribution-terraform-state"
           terraform workspace select stable
           terraform fmt
         env:
-          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_CREDENTIALS: ${{ secrets.PRODUCTION_GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Docker pull
         continue-on-error: true
-        run: docker pull "eu.gcr.io/psessentials-production/accounts-vue-components-package:latest"
+        run: docker pull "eu.gcr.io/distribution-production-308520/accounts-vue-components-package:latest"
 
       - name: Build package
         run: |
           docker build \
             --target=package \
-            --cache-from="eu.gcr.io/psessentials-production/accounts-vue-components-package:latest" \
-            --tag="eu.gcr.io/psessentials-production/accounts-vue-components-package:latest" .
-          docker push "eu.gcr.io/psessentials-production/accounts-vue-components-package:latest"
+            --cache-from="eu.gcr.io/distribution-production-308520/accounts-vue-components-package:latest" \
+            --tag="eu.gcr.io/distribution-production-308520/accounts-vue-components-package:latest" .
+          docker push "eu.gcr.io/distribution-production-308520/accounts-vue-components-package:latest"
 
       - name: Build and push finale image
         run: |
           docker build . \
-            --tag="eu.gcr.io/psessentials-production/accounts-vue-components:latest" \
-            --cache-from="eu.gcr.io/psessentials-production/accounts-vue-components-package:latest"
-          docker push "eu.gcr.io/psessentials-production/accounts-vue-components:latest"
+            --tag="eu.gcr.io/distribution-production-308520/accounts-vue-components:latest" \
+            --cache-from="eu.gcr.io/distribution-production-308520/accounts-vue-components-package:latest"
+          docker push "eu.gcr.io/distribution-production-308520/accounts-vue-components:latest"
         env:
-          GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
           TAG: ${{ steps.get_tag.outputs.TAG }}
 
       - name: Terraform apply
@@ -68,4 +67,4 @@ jobs:
         run: terraform apply -auto-approve
         env:
           SHA: ${{ github.sha }}
-          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_CREDENTIALS: ${{ secrets.PRODUCTION_GOOGLE_APPLICATION_CREDENTIALS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,12 @@ jobs:
           echo $GOOGLE_APPLICATION_CREDENTIALS > token.json
           gcloud auth activate-service-account --key-file=token.json
           gcloud container clusters get-credentials $GCLOUD_CLUSTER \
-          --zone europe-west1-c --project psessentials-integration
+          --zone europe-west1-c --project distribution-integration
           gcloud auth configure-docker
           rm token.json
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GCLOUD_CLUSTER: ${{ secrets.GCLOUD_CLUSTER }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.INTEGRATION_GOOGLE_APPLICATION_CREDENTIALS }}
+          GCLOUD_CLUSTER: ${{ secrets.INTEGRATION_GCLOUD_CLUSTER }}
 
       - name: Checkout repository
         uses: actions/checkout@master

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,11 @@ yarn-error.log*
 *.sw?
 .nova
 
+#Terraform
+cloud/.terraform*
+cloud/gcp-token.json
+gcp-token.json
+cloud/.terraform.lock.hcl
+cloud/.terraform/environment
 .terraform
+

--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ yarn start-storybook
 ```
 
 and go on [local storybook](http://localhost:33199/?path=/docs/introduction--page)
-or use online [integration storybook](https://storybook-accounts.psessentials.net/?path=/docs/introduction--page)
+or use online [integration storybook](https://storybook-accounts.distribution.prestashop.net/?path=/docs/introduction--page)
 
 ## Storybooks
 
 Storybook integration (trigger on PR labeled 'quality assurance needed'): 
 
-https://storybook-accounts.psessentials-integration.net/
+https://storybook-accounts.distribution-integration.prestashop.net/
 
 Storybook production (trigger on push master/main) : 
 
-https://storybook-accounts.psessentials.net/
+https://storybook-accounts.distribution.prestashop.net/
 
 ## CDN
 

--- a/cloud/backend.tf
+++ b/cloud/backend.tf
@@ -5,5 +5,7 @@
 terraform {
   backend "gcs" {
     prefix = "terraform/accounts-vue-components"
+    bucket = "integration-ditribution-terraform-state"
+
   }
 }

--- a/cloud/provider.tf
+++ b/cloud/provider.tf
@@ -7,6 +7,13 @@ provider "google" {
   zone    = data.terraform_remote_state.services.outputs.default_zone
 }
 
+provider "google-beta" {
+  version = "3.40.0"
+  project = local.project
+  region  = data.terraform_remote_state.services.outputs.region
+  zone    = data.terraform_remote_state.services.outputs.default_zone
+}
+
 # https://www.terraform.io/docs/providers/kubernetes/index.html
 provider "kubernetes" {
   version = "1.10.0"

--- a/cloud/remote_state.tf
+++ b/cloud/remote_state.tf
@@ -7,7 +7,8 @@ data "terraform_remote_state" "services" {
 
   # see https://www.terraform.io/docs/backends/types/gcs.html
   config = {
+    #    prefix = "terraform/services/gcp"
     prefix = "terraform/services"
-    bucket = local.project
+    bucket = "integration-ditribution-terraform-state"
   }
 }

--- a/cloud/variables.tf
+++ b/cloud/variables.tf
@@ -11,7 +11,7 @@ locals {
     }
     managed_zone = {
       alpha = "distribution-integration-net"
-      stable = "distribution-integration-net"
+      stable = "distribution-production-net"
     }
     environment = {
       alpha = "integration"

--- a/cloud/variables.tf
+++ b/cloud/variables.tf
@@ -6,20 +6,20 @@ locals {
 
   config = {
     project = {
-      alpha = "psessentials-integration"
-      stable = "psessentials-production"
+      alpha = "distribution-integration"
+      stable  = "distribution-production-308520"
     }
     managed_zone = {
-      alpha   = "psessentials-integration-net"
-      stable  = "psessentials-net"
+      alpha = "distribution-integration-net"
+      stable = "distribution-integration-net"
     }
     environment = {
       alpha = "integration"
       stable = "production"
     }
     url = {
-      alpha = "storybook-accounts.psessentials-integration.net"
-      stable = "storybook-accounts.psessentials.net"
+      alpha = "storybook-accounts.distribution-integration.prestashop.net"
+      stable = "storybook-accounts.distribution.prestashop.net"
     }
   }
 }


### PR DESCRIPTION
Working on moving the accounts storybooks app to the new distribution infra, including : 
- [x] Updated README for new URLS
- [x] Updated terraform configuration to use new distribution environments
- [x] Updated ingress configuration to use google managed certificate
- [x]  Added google-beta provider in order to provision google managed certificate
- [x] Updated gitignore to not version terraform init files
- [x] Updated actions workflows to work with new distribution environment
- [x] Added new Github Secrets to smoothly manage the transition 