### PR TITLE
fix: compat v4

### DIFF
--- a/src/lib/ContextValidator.js
+++ b/src/lib/ContextValidator.js
@@ -29,8 +29,8 @@ export const contextSchema = Joi.object().keys({
   psAccountsIsUptodate: Joi.boolean().default(true),
   psAccountsIsEnabled: Joi.boolean().default(true),
 
-  employeeId: Joi.number().required(),
-  isOnboardedV4: Joi.boolean().required(),
+  employeeId: Joi.number(),
+  isOnboardedV4: Joi.boolean(),
 
   psAccountsInstallLink: Joi.string().uri().allow(null).default(null),
   psAccountsEnableLink: Joi.string().uri().allow(null).default(null),


### PR DESCRIPTION
change required status for v5 fields