### PR TITLE
fix condition to display the mailto link

### DIFF
--- a/src/components/alert/AccountUserNotSuperAdmin.vue
+++ b/src/components/alert/AccountUserNotSuperAdmin.vue
@@ -5,7 +5,7 @@
     show
   >
     <p>{{ t('psaccounts.account.needToBeAdmin') }}</p>
-    <p v-if="adminEmail">
+    <p v-if="validatedContext.superAdminEmail">
       {{ t('psaccounts.account.pleaseContact') }}
       <a
         @click="trackClick"


### PR DESCRIPTION
The adminEmail variable ise replaced by validatedContext.superAdminEmail.