### PR TITLE
Fix: Change title h3 to p to avoid conflicts with global rules of prestakit

### DIFF
--- a/src/components/panel/accountSubComponents/AccountHeader.vue
+++ b/src/components/panel/accountSubComponents/AccountHeader.vue
@@ -6,9 +6,9 @@
     >
       <CheckIcon class="acc-text-white" />
     </span>
-    <h3 class="acc-m-0 acc-font-primary acc-font-semibold">
+    <p class="acc-m-0 acc-font-primary acc-font-semibold">
       <slot />
-    </h3>
+    </p>
   </div>
 </template>
 


### PR DESCRIPTION
# 📚 Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Fixes a style issue for the panel title when the rbm/psx is using Prestakit

## ❓ Type of change

Please delete options that are not relevant.

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation (updates to the documentation or readme)

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes for storybook
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->