### PR TITLE
fix: tracking source of module without shops payload

### DIFF
--- a/src/components/PsAccounts.vue
+++ b/src/components/PsAccounts.vue
@@ -29,6 +29,7 @@
       <template v-if="!hasBlockingAlert">
         <AccountPanel
           :accounts-ui-url="validContext.accountsUiUrl"
+          :app="app"
           :backend-user="validContext.backendUser"
           :onboarding-link="validContext.onboardingLink"
           :shops="shops"
@@ -104,6 +105,8 @@ export default defineComponent({
     const {identify, trackAccountComponentViewed} = useSegmentTracking();
     const hasError = ref(false);
 
+    const app = computed(() => context.value.psxName);
+
     const hasAllShopsLinked = computed(() => shopsWithUrl.value.every((shop) => shop.uuid));
 
     const hasBlockingAlert = computed(() => !context.value.psAccountsIsInstalled
@@ -123,6 +126,7 @@ export default defineComponent({
 
     return {
       validContext: context,
+      app,
       hasAllShopsLinked,
       hasBlockingAlert,
       hasError,

--- a/src/components/crossdomains/LinkShopModal.vue
+++ b/src/components/crossdomains/LinkShopModal.vue
@@ -14,6 +14,7 @@
           v-click-outside="close"
         >
           <link-shop-crossdomain
+            :app="app"
             :specificUiUrl="specificUiUrl"
             :shops="shops"
             :onBoardingFinished="close"
@@ -46,6 +47,10 @@ export default defineComponent({
     clickOutside: vClickOutside.directive,
   },
   props: {
+    app: {
+      type: String,
+      required: true,
+    },
     shops: {
       type: Array,
       required: true,

--- a/src/components/crossdomains/linkShopCrossDomain.ts
+++ b/src/components/crossdomains/linkShopCrossDomain.ts
@@ -1,45 +1,59 @@
 import * as zoid from 'zoid/dist/zoid.frameworks';
 
 export default zoid.create({
-  tag: 'crossdomains-account-link-shop',
+  tag: "crossdomains-account-link-shop",
   // TODO Put accounts-ui prod url when there is no env
-  url: ({props}: { props: Record<string, unknown> }) => `${props.accountsUiUrl}${props.specificUiUrl}/?cdc=true`,
+  url: ({ props }: { props: Record<string, unknown> }) =>
+    `${props.accountsUiUrl}${props.specificUiUrl}/`,
 
-  context: 'iframe',
+  context: "iframe",
 
   // The size of the component on their page. Only px and % strings are supported
   dimensions: {
-    height: '100%',
-    width: '100%',
+    height: "100%",
+    width: "100%",
   },
 
   props: {
+    app: {
+      type: "string",
+      required: true,
+      queryParam: true,
+    },
+    cdc: {
+      type: "boolean",
+      required: false,
+      default: function () {
+        return true;
+      },
+      queryParam: true,
+    },
     shops: {
-      type: 'array',
+      type: "array",
       required: true,
     },
     specificUiUrl: {
-      type: 'string',
+      type: "string",
       required: true,
     },
     onBoardingFinished: {
-      type: 'function',
+      type: "function",
       required: false,
     },
     tracking: {
-      type: 'object',
+      type: "object",
       required: false,
     },
     onLogout: {
-      type: 'function',
+      type: "function",
       required: false,
     },
     accountsUiUrl: {
-      type: 'string',
+      type: "string",
       required: true,
     },
     triggerFallback: {
-      type: 'function',
+      type: "function",
       required: false,
     },
   },

--- a/src/components/panel/AccountPanel.vue
+++ b/src/components/panel/AccountPanel.vue
@@ -21,6 +21,7 @@
         <AccountLinkToUi
           class="acc-mt-2 md:acc-mt-0"
           :accounts-ui-url="accountsUiUrl"
+          :app="app"
           :backend-user="backendUser"
           :onboarding-link="onboardingLink"
           :shops="shopsWithUrl"
@@ -89,6 +90,13 @@ export default defineComponent({
          * should be https://accounts.distribution.prestashop.net/en
          */
     accountsUiUrl: {
+      type: String,
+      required: true,
+    },
+    /**
+         * Name of the module
+         */
+    app: {
       type: String,
       required: true,
     },

--- a/src/components/panel/accountSubComponents/AccountLinkToUi.vue
+++ b/src/components/panel/accountSubComponents/AccountLinkToUi.vue
@@ -42,6 +42,7 @@
     <link-shop-modal
       ref="linkShopModal"
       :accounts-ui-url="accountsUiUrl"
+      :app="app"
       :on-boarding-link="onboardingLink"
       :shops="unlinkedShopsWithEmployeeId"
       :specific-ui-url="specificUiUrl"
@@ -71,6 +72,10 @@ export default defineComponent({
   },
   props: {
     accountsUiUrl: {
+      type: String,
+      required: true,
+    },
+    app: {
       type: String,
       required: true,
     },


### PR DESCRIPTION
# 📚 Description

On PrestaShop Backoffice, when we click on "unlink" or "view my associated shops" buttons, in most of the cases, we pass an empty shops payload (because we don't have non associated shops in the context) so the `source` cannot be obtained from `shopStore.shops[0]?.moduleName`. We should pass an app query params.

## ❓ Type of change

Please delete options that are not relevant.

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation (updates to the documentation or readme)

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes for storybook
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->