### PR TITLE
Fix error about custom component already defined

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ const installGlobalComponents = {
 const PsAccountsWebComponent = defineCustomElement(PsAccounts);
 
 const init = () => {
-  customElements.define('prestashop-accounts', PsAccountsWebComponent);
+  customElements.get('prestashop-accounts') || customElements.define('prestashop-accounts', PsAccountsWebComponent);
 };
 
 export default installGlobalComponents;


### PR DESCRIPTION
# 📚 Description

Fixes the issue "Uncaught DOMException: CustomElementRegistry.define: 'prestashop-accounts' has already been defined as a custom element", when we initialize the component several times without refreshing the page.

![Capture d’écran du 2023-07-10 15-27-56](https://github.com/PrestaShopCorp/prestashop_accounts_vue_components/assets/6768917/89d2b404-506f-43ce-aa11-56969d8b0a4c)

Solution based on https://stackoverflow.com/a/57696496

## ❓ Type of change

Please delete options that are not relevant.

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation (updates to the documentation or readme)

## 📝 Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes for storybook
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->