### PR TITLE
feat: add invitation banner for pending invitation

### DIFF
--- a/src/components/PsAccounts.vue
+++ b/src/components/PsAccounts.vue
@@ -36,6 +36,15 @@
         data-testid="account-user-not-super-admin"
       />
       <template v-if="!hasBlockingAlert">
+        <InvitationBanner
+          :app="context.psxName"
+          :accounts-ui-url="context.accountsUiUrl"
+          :admin-ajax-link="context.adminAjaxLink"
+          :shops="shopsToLink"
+          :shops-in-context="shopsInContext"
+          :shop-context="context.currentContext ? context.currentContext.type : 4"
+          data-testid="invitatiion-banner"
+        />
         <AccountPanel
           :accounts-ui-url="context.accountsUiUrl"
           :app="context.psxName"
@@ -76,21 +85,21 @@ import { Context, Shop, ShopContext } from '@/types/context';
 import { contextSchema } from '@/lib/ContextValidator';
 import '@/assets/css/index.css';
 import { hasSlotContent } from '@/lib/utils';
+/**
+ * `PsAccounts` will automate pre-requisites checks and will call sub-components directly
+ * to ensure each functional case is covered for you. You can use the default slots
+ * that will be disabled if the user account is not well linked (you should put your
+ * module configuration panel here)
+ */
+interface PsAccountsProps {
   /**
-   * `PsAccounts` will automate pre-requisites checks and will call sub-components directly
-   * to ensure each functional case is covered for you. You can use the default slots
-   * that will be disabled if the user account is not well linked (you should put your
-   * module configuration panel here)
-   */
-  interface PsAccountsProps {
-    /**
-    * The whole context object given
-    * [by ps\_accounts module presenter function](https://github.com/PrestaShopCorp/prestashop-accounts-installer#register-as-a-service-in-your-psx-container-recommended).
-    * If left empty (by default), the context will be retrieved from JS global
-    * var window.contextPsAccounts automatically.
-    */
-    context?: Context;
-  }
+  * The whole context object given
+  * [by ps\_accounts module presenter function](https://github.com/PrestaShopCorp/prestashop-accounts-installer#register-as-a-service-in-your-psx-container-recommended).
+  * If left empty (by default), the context will be retrieved from JS global
+  * var window.contextPsAccounts automatically.
+  */
+  context?: Context;
+}
 const props = withDefaults(defineProps<PsAccountsProps>(), {
   context: () => window.contextPsAccounts || {}
 });

--- a/src/components/invitation/InvitationBanner.mdx
+++ b/src/components/invitation/InvitationBanner.mdx
@@ -1,0 +1,46 @@
+import { Meta, Story, Description, ArgTypes } from "@storybook/blocks";
+import {
+  NotLinked,
+  PartiallyLinked,
+  Linked,
+  SlotTemplate,
+} from "./InvitationBanner.stories";
+
+import InvitationBanner from "./InvitationBanner.vue";
+
+<Meta title="Components/Panels/InvitationBanner" />
+
+# Invitation banner behavior
+
+The `InvitationBanner` component is here to show if the user have a pending invitation request.
+This component is only in charge of displaying a banner if a shop is linked and have a pending invitation for this shop.
+
+## If an association is pending a banner is displayed:
+
+<Story of={NotLinked} height="175px" />
+
+Otherwise, if there is no association, the banner is not displayed
+
+---
+
+# Integration
+
+This component is a sub-component of PS Accounts and is shown above the `AccountsPanel` sub-component.
+
+
+```html
+<InvitationBanner
+  :accounts-ui-url="validContext.accountsUiUrl"
+  :admin-ajax-link="validContext.adminAjaxLink"
+  :app="context.psxName"
+  :shop-context="validContext.currentContext.type"
+  :shops="shopsToLink"
+  :shops-in-context="shopsInContext"
+>
+</InvitationBanner>
+```
+
+# Technical details
+
+<Description of={InvitationBanner} />
+<ArgTypes of={InvitationBanner} />

--- a/src/components/invitation/InvitationBanner.spec.ts
+++ b/src/components/invitation/InvitationBanner.spec.ts
@@ -1,0 +1,32 @@
+import { ShopContext } from '@/types/context';
+import { faker } from '@faker-js/faker';
+import InvitationBanner from '@/components/invitation/InvitationBanner.vue';
+import { describe, it, expect } from 'vitest';
+import { MountingOptions, mount } from '@vue/test-utils';
+type ComponentProps = InstanceType<typeof InvitationBanner>['$props'];
+
+describe('InvitationBanner component tests', () => {
+  const factory = (
+    props: Partial<ComponentProps> = {},
+    options: MountingOptions<any> = {}
+  ) => {
+    mount(InvitationBanner, {
+      props: {
+        accountsUiUrl: faker.internet.url(),
+        adminAjaxLink: faker.internet.url(),
+        app: faker.lorem.word(),
+        isSuperAdmin: true,
+        shopContext: ShopContext.Shop,
+        shops: [],
+        shopsInContext: [],
+        ...props
+      },
+      ...options
+    });
+  };
+
+  it('should do an empty test (TODO)', () => {
+    factory();
+    expect(true).toBeTruthy();
+  });
+});

--- a/src/components/invitation/InvitationBanner.vue
+++ b/src/components/invitation/InvitationBanner.vue
@@ -1,0 +1,132 @@
+<template>
+  <puik-alert
+    v-if="!loading && firstInvitation"
+    class="acc-p-6 acc-mb-4"
+    :title="t('psaccounts.account.invitationBanner.title', { count: invitations.length })"
+    variant="warning"
+    :disabled-borders="true"
+    :button-label="t('psaccounts.account.invitationBanner.button', invitations.length)"
+    @click="openInvitationsModal()"
+  >
+    <div>
+      {{ t(`psaccounts.account.invitationBanner.messageStart`) }}
+      <b>{{ firstInvitation.from.companyName }}</b>
+      {{ t(`psaccounts.account.invitationBanner.messageEnd`) }}
+    </div>
+  </puik-alert>
+</template>
+
+<script setup lang="ts">
+import { Shop } from '@/types/context';
+import { useLocale } from '@/composables/useLocale';
+import { ref, onMounted, computed, ComputedRef } from 'vue';
+import { useLinkShopCrossDomain } from '@/composables/useLinkShopCrossDomain';
+const loading = ref(true);
+const invitations = ref([] as Invitation[]);
+
+/**
+   * This sub-component can be used in a custom integration when the `PsAccounts` component
+   * does not meets special needs.
+   * This part will display a block to let the user link his account through a button.
+   */
+interface InvitationBannerProps {
+  accountsUiUrl: string;
+  adminAjaxLink: string;
+  app: string;
+  /**
+  * In multistore context, contains the whole shop tree (all groups and all shops).
+  * In single shop context, contains this shop information
+  */
+  shops: Shop[];
+  shopsInContext: Shop[];
+  /**
+  * Current shop context, possible values :<br />
+  * 4 - all shops<br />
+  * 2 - group<br />
+  * 1 - single shop
+  */
+  shopContext: number;
+}
+
+interface Invitation {
+  from: {
+    userId: string;
+    userEmail: string;
+    userName: string;
+    companyName: string;
+  };
+  to: {
+    shopUrl: string;
+    shopId: string;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+  status: string;
+}
+const props = withDefaults(defineProps<InvitationBannerProps>(), {
+  shops: () => []
+});
+
+const { t } = useLocale();
+
+const { open, state } = useLinkShopCrossDomain({
+  accountsUiUrl: props.accountsUiUrl,
+  app: props.app,
+  shops: props.shops
+});
+
+const openInvitationsModal = () => {
+  state.specificUiUrl = '/invitation';
+  open();
+};
+
+const firstInvitation: ComputedRef<Invitation | undefined> = computed(() => {
+  if (invitations.value.length !== 0) {
+    return invitations.value[0];
+  }
+  return undefined;
+});
+
+onMounted(async () => {
+  if (props.shopContext !== 1 || props.shopsInContext.length !== 1 || !props.shopsInContext[0].uuid) {
+    return;
+  }
+  /*
+  invitations.value = [
+    {
+      from: {
+        userId: '1',
+        userEmail: 'Expert email',
+        userName: 'expert name',
+        companyName: 'Expert company'
+      },
+      to: {
+        shopUrl: '',
+        shopId: ''
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      status: InvitationStatus.PENDING
+    }
+  ];
+  loading.value = false;
+  */
+
+  try {
+    loading.value = true;
+    const response = await fetch(props.adminAjaxLink + '&action=getInvitations', { method: 'GET' });
+    if (!response.ok) {
+      throw new Error(`An error has occured: ${response.status}`);
+    }
+    const data = await response.json();
+
+    if (data.invitations.length > 0) {
+      invitations.value = data.invitations as Invitation[];
+    }
+  } catch (e) {
+    loading.value = false;
+  }
+  loading.value = false;
+});
+
+</script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,6 +37,12 @@
       "authorizedPartially": "Your stores are partially linked to a PrestaShop account",
       "authorizedMultishop": "All your stores are linked to a PrestaShop account",
       "connectButton": "Link",
+      "invitationBanner": {
+        "button": "View my invitation|View my invitations",
+        "messageStart": "An expert from",
+        "messageEnd": "is waiting for an answer to his invitation.",
+        "title": "You have {count} request awaiting|You have {count} requests awaiting"
+      },
       "moduleUpdateInformation": {
         "part1": "New update: ",
         "part2": "you can manage your linked stores.",

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -16,6 +16,7 @@ declare module 'vue' {
     AlertShopUrlShouldExists: typeof import('./../components/alert/AlertShopUrlShouldExists.vue')['default']
     AlertUserNotSuperAdmin: typeof import('./../components/alert/AlertUserNotSuperAdmin.vue')['default']
     BaseOverlay: typeof import('./../components/common/BaseOverlay.vue')['default']
+    InvitationBanner: typeof import('./../components/invitation/InvitationBanner.vue')['default']
     PsAccounts: typeof import('./../components/PsAccounts.vue')['default']
     PuikAlert: typeof import('@prestashopcorp/puik/es')['PuikAlert']
     PuikButton: typeof import('@prestashopcorp/puik/es')['PuikButton']

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -11,6 +11,7 @@ export interface BackendUser {
 }
 
 export interface Context {
+  adminAjaxLink: string
   accountsUiUrl: string
   backendUser: BackendUser
   currentContext: CurrentContext


### PR DESCRIPTION
# 📚 Description

A new Banner to display pending invitation above the link pannel 

Feat [ACCOUNT-1950](https://forge.prestashop.com/browse/ACCOUNT-1950)
Sync w/ PRs: https://github.com/PrestaShopCorp/ps_accounts/pull/356

## ❓ Type of change

- [✅ ] 📦 New feature (a non-breaking change that adds functionality)

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes for storybook
