### PR TITLE
feat: add defaults values to existing context

### DIFF
--- a/src/components/PsAccounts.vue
+++ b/src/components/PsAccounts.vue
@@ -101,7 +101,7 @@ interface PsAccountsProps {
   context?: Context;
 }
 const props = withDefaults(defineProps<PsAccountsProps>(), {
-  context: () => window.contextPsAccounts || {}
+  context: () => (window.contextPsAccounts ? contextSchema.validate(window.contextPsAccounts).value : {}) as Context
 });
 const errors = ref<string[]>([]);
 

--- a/src/lib/ContextValidator.ts
+++ b/src/lib/ContextValidator.ts
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import { ShopContext } from '@/types/context';
 
 export const backendUserSchema = Joi.object().keys({
   email: Joi.string().email({ tlds: false }).allow(null).default(null),
@@ -55,7 +56,7 @@ export const userSchema = Joi.object().keys({
 export const contextSchema = Joi.object().keys({
   accountsUiUrl: Joi.string().allow(null).default(null),
   backendUser: backendUserSchema.optional().allow({}).default({}),
-  currentContext: currentContextSchema.optional().allow({}).default({}),
+  currentContext: currentContextSchema.optional().default({ type: ShopContext.All }),
   // dependencies
   onboardingLink: Joi.string().uri().optional().allow(null)
     .allow('')


### PR DESCRIPTION
# 📚 Description

Actually there is an error when ps_accounts is not installed and not install via ps_accounts_installer, there are errors because currentContext does not exist and it's a regression from the previous version of vue_components

Fixes # (issue) / [ACCOUNT-1993](https://forge.prestashop.com/browse/ACCOUNT-1993)
Sync w/ PRs:

## ❓ Type of change

Please delete options that are not relevant.

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation (updates to the documentation or readme)

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes for storybook
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->